### PR TITLE
Modify EICAR matching condition to follow spec and avoid false positives

### DIFF
--- a/yara/rules/Multi_EICAR.yar
+++ b/yara/rules/Multi_EICAR.yar
@@ -4,7 +4,7 @@ rule Multi_EICAR_ac8f42d6 {
         id = "ac8f42d6-52da-46ec-8db1-5a5f69222a38"
         fingerprint = "bb0e0bdf70ec65d98f652e2428e3567013d5413f2725a2905b372fd18da8b9dd"
         creation_date = "2021-01-21"
-        last_modified = "2022-01-13"
+        last_modified = "2026-04-15"
         threat_name = "Multi.EICAR.Not-a-virus"
         severity = 1
         arch_context = "x86, arm64"
@@ -14,6 +14,6 @@ rule Multi_EICAR_ac8f42d6 {
     strings:
         $a = "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" ascii fullword
     condition:
-        all of them
+        $a at 0 and filesize <= 128
 }
 


### PR DESCRIPTION
The current yara rule for the EICAR test file is too broad and doesn't follow the spec, causing false positives.

The spec:
> Any anti-virus product that supports the EICAR test file should detect it in any file providing that the file starts with the following 68 characters, and is exactly 68 bytes long

> The first 68 characters is the known string. It may be optionally appended by any combination of whitespace characters with the total file length not exceeding 128 characters. The only whitespace characters allowed are the space character, tab, LF, CR, CTRL-Z.

See:
- https://en.wikipedia.org/wiki/EICAR_test_file
- https://www.eicar.org/download-anti-malware-testfile/

This will fix false positive, for example matches of any file that contains the full string somewhere in a file. Which could be just a regular binary/dll/database which also just have a reference of the EICAR string itself and therefore contains this string somewhere.

The fix will follow the spec by only matching on files which actually start with the string on byte 0 and are not bigger than 128 bytes.